### PR TITLE
Removed reference to user in Pythopn code

### DIFF
--- a/CalliopEO.py
+++ b/CalliopEO.py
@@ -10,10 +10,12 @@ import re
 
 blk = blkinfo.BlkDiskInfo()
 
-#TEMP_MOUNT_MINI = "/tmp/mini"
-TEMP_MOUNT_MINI = "/home/calliope/mnt/mini"
-#TEMP_MOUNT_FLASH = "/tmp/flash"
-TEMP_MOUNT_FLASH = "/home/calliope/mnt/flash"
+TEMP_MOUNT_MINI = "~/mnt/mini"
+TEMP_MOUNT_FLASH = "~/mnt/flash"
+
+# Expand mount path if they contain tilde
+TEMP_MOUNT_MINI = os.path.expanduser(TEMP_MOUNT_MINI)
+TEMP_MOUNT_FLASH = os.path.expanduser(TEMP_MOUNT_FLASH)
 
 #MODEL_MINI_VALUE = "SEGGER MSD Volume"
 MODEL_MINI_REGEXP = 'SEGGER[-_ ]{1}MSD[-_ ]{1}Volume'


### PR DESCRIPTION
This pull requests references the issue #3 . The function [os.path.expanduser()](https://docs.python.org/3/library/os.path.html#os.path.expanduser) is used to replace an initial `~` by the environment variable `HOME` if it is set; otherwise the current user’s home directory is looked up in the password directory.

This change was successfully tested.